### PR TITLE
Add branch name to the tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - project-refactor
 ##
 jobs:
   calculate_new_tag:
@@ -28,9 +29,9 @@ jobs:
           export MAJOR=$(echo $LAST_TAG | awk -F'.' '{print $1}')
           export MINOR=$(echo $LAST_TAG | awk -F'.' '{print $2}')
           export PATCH=$(echo $LAST_TAG | awk -F'.' '{print $3}' | awk -F'-' '{print $1}')
-          export SUFFIX=$(echo $LAST_TAG | awk -F'-' '{print $2}')
+          export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD | tr '/' '-') # Convert slashes to dashes if present
           export NEXT_PATCH=$((PATCH + 1))
-          export NEW_TAG="$MAJOR.$MINOR.$NEXT_PATCH-$SUFFIX"
+          export NEW_TAG="$MAJOR.$MINOR.$NEXT_PATCH-$BRANCH_NAME"
           echo "new tag is: $NEW_TAG"
           echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT          
           


### PR DESCRIPTION
We want to build images from the branch `project-refactor`. I changed the logic for calculating a new tag so the suffix of the tag will be the branch name.