### PR TITLE
Add support for universal platform offerings in DiscoveryService and OfferingService

### DIFF
--- a/apps/api/src/modules/device/discovery/discovery.service.ts
+++ b/apps/api/src/modules/device/discovery/discovery.service.ts
@@ -7,6 +7,7 @@ import { DiscoveryResDto } from '@app/common/dto/discovery';
 import { MicroserviceClient, MicroserviceName } from '@app/common/microservice-client';
 import { DeviceDiscoverDto } from '@app/common/dto/im';
 import { ComponentOfferingRequestDto, DeviceComponentsOfferingDto, MapOfferingStatus, OfferingMapProductsResDto, OfferingMapResDto, ReleaseOfferingDto, PlatformDeviceTypeTreeDto, DeviceTypeProjectRefDto } from '@app/common/dto/offering';
+import { UNIVERSAL_PLATFORM_TOKEN } from '@app/common/dto/devices-hierarchy';
 import { DeviceTypeOfferingDto, PlatformOfferingDto } from '@app/common/dto/offering/dto/offering.dto';
 import { ComponentV2Dto } from '@app/common/dto/upload';
 import { OfferingService } from '../../offering/offering.service';
@@ -38,7 +39,7 @@ export class DiscoveryService {
       ?.map(comp => comp.catalogId)
 
     // Fetch offerings in parallel from multiple sources
-    const promises: Promise<DeviceComponentsOfferingDto | DeviceTypeOfferingDto | PlatformOfferingDto | RuleDefinition[] | null>[] = [];
+    const promises: Promise<DeviceComponentsOfferingDto | DeviceTypeOfferingDto | PlatformOfferingDto | PlatformOfferingDto[] | RuleDefinition[] | null>[] = [];
 
     // 0. Get device restrictions
     promises.push(
@@ -75,22 +76,34 @@ export class DiscoveryService {
 
     // 3. Get platform offerings (includes all device types under platform)
     if (offeringDto.platforms && offeringDto.platforms.length > 0) {
-      offeringDto.platforms.forEach(platform => {
+      if (offeringDto.platforms.includes(UNIVERSAL_PLATFORM_TOKEN)) {
+        // Universal token: fetch offerings for ALL platforms at once
         promises.push(
-          lastValueFrom(this.offeringService.getOfferingForPlatform({ platformIdentifier: platform }, { withDependencies: true }))
+          lastValueFrom(this.offeringService.getAllPlatformsOffering({ withDependencies: true }))
             .catch(err => {
-              this.logger.error(`Error getting offering for platform ${platform}: ${err}`);
+              this.logger.error(`Error getting all platforms offering: ${err}`);
               return null;
             })
         );
-      });
+      } else {
+        offeringDto.platforms.forEach(platform => {
+          promises.push(
+            lastValueFrom(this.offeringService.getOfferingForPlatform({ platformIdentifier: platform }, { withDependencies: true }))
+              .catch(err => {
+                this.logger.error(`Error getting offering for platform ${platform}: ${err}`);
+                return null;
+              })
+          );
+        });
+      }
     }
 
     const results = await Promise.all(promises);
     const [restrictionsResult, componentOfferingResult, ...otherOfferingResults] = results;
 
     // Merge all results into unified ReleaseOfferingDto[]
-    const offeringResults = [componentOfferingResult, ...otherOfferingResults];
+    const flatOtherResults = (otherOfferingResults as any[]).flatMap(r => Array.isArray(r) ? r : [r]);
+    const offeringResults = [componentOfferingResult, ...flatOtherResults];
     const releaseMap = this.mergeOfferingResults(offeringResults as (DeviceComponentsOfferingDto | DeviceTypeOfferingDto | PlatformOfferingDto | null)[]);
 
     const res = new DeviceComponentsOfferingDto();

--- a/apps/api/src/modules/offering/offering.service.ts
+++ b/apps/api/src/modules/offering/offering.service.ts
@@ -18,6 +18,10 @@ export class OfferingService implements OnModuleInit {
     return this.offeringClient.send(OfferingTopics.GET_OFFERING_FOR_PLATFORM, bindParams)
   }
 
+  getAllPlatformsOffering(query?: { withDependencies?: boolean }) {
+    return this.offeringClient.send(OfferingTopics.GET_OFFERING_FOR_ALL_PLATFORMS, query ?? {});
+  }
+
   getOfferingForDeviceType(params: DeviceTypeOfferingParams, query: DeviceTypeOfferingFilterQuery) {
     query.deviceTypeIdentifier = params.deviceTypeIdentifier;
     query.withDependencies = query.withDependencies ?? false;

--- a/libs/common/src/dto/devices-hierarchy/constants.ts
+++ b/libs/common/src/dto/devices-hierarchy/constants.ts
@@ -1,0 +1,1 @@
+export const UNIVERSAL_PLATFORM_TOKEN = 'universal';

--- a/libs/common/src/dto/devices-hierarchy/index.ts
+++ b/libs/common/src/dto/devices-hierarchy/index.ts
@@ -1,3 +1,4 @@
 export * from './dto/device-type.dto'
 export * from './dto/platform.dto'
 export * from './dto/hierarchy-tree.dto'
+export * from './constants'

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -81,6 +81,7 @@ export const OfferingTopics = {
     GET_OFFERING_FOR_DEVICE_TYPE: `getapp-offering.get-offering-for-device-type${region}`,
     GET_OFFERING_FOR_PROJECT: `getapp-offering.get-offering-for-project${region}`,
     GET_OFFERING_FOR_ALL_PROJECTS: `getapp-offering.get-offering-for-all-project${region}`,
+    GET_OFFERING_FOR_ALL_PLATFORMS: `getapp-offering.get-offering-for-all-platforms${region}`,
     GET_OFFER_OF_COMP: `getapp-offering.get-offering-of-comp${region}`,
 
     // Policies


### PR DESCRIPTION
- Introduced UNIVERSAL_PLATFORM_TOKEN constant for universal platform identification.
- Updated DiscoveryService to handle fetching offerings for all platforms.
- Added getAllPlatformsOffering method in OfferingService to retrieve offerings for all platforms.
- Exported UNIVERSAL_PLATFORM_TOKEN from devices-hierarchy constants.

This pull request introduces support for a "universal platform" token in the device discovery process, enabling the system to fetch offerings for all platforms in a single operation. It adds a new constant for the universal platform, updates the discovery and offering services to handle this token, and introduces a new microservice topic for retrieving all platform offerings. The changes streamline how platform offerings are requested and merged, improving efficiency and maintainability.

**Universal platform support:**

* Added `UNIVERSAL_PLATFORM_TOKEN` constant in `libs/common/src/dto/devices-hierarchy/constants.ts` and exported it via the module index for easy import. [[1]](diffhunk://#diff-3b061e3bf0fe1d7e705223d8a75688437e0d43287df0d47e52273b2adecbde13R1) [[2]](diffhunk://#diff-cbe6ffe4bba4a908a17f54a1cf158b44aedee872de3ec31eb8ed93369c385323R4)
* Updated `DiscoveryService` to check for the universal platform token in `offeringDto.platforms`. If present, it fetches offerings for all platforms at once using a new service method; otherwise, it fetches offerings per platform as before. [[1]](diffhunk://#diff-369b13261ba5ab9731a4a1c5e711f60d2c26d086c67132388d1506d1c04ecd30R10) [[2]](diffhunk://#diff-369b13261ba5ab9731a4a1c5e711f60d2c26d086c67132388d1506d1c04ecd30R79-R88)

**Offering service enhancements:**

* Added `getAllPlatformsOffering` method to `OfferingService` to request offerings for all platforms from the microservice.
* Introduced a new microservice topic, `GET_OFFERING_FOR_ALL_PLATFORMS`, in `OfferingTopics` for this purpose.

**Result handling improvements:**

* Modified the merging logic in `DiscoveryService` to handle arrays of offerings (as returned by the universal platform query) by flattening the results before merging. [[1]](diffhunk://#diff-369b13261ba5ab9731a4a1c5e711f60d2c26d086c67132388d1506d1c04ecd30L41-R42) [[2]](diffhunk://#diff-369b13261ba5ab9731a4a1c5e711f60d2c26d086c67132388d1506d1c04ecd30R99-R106)