### PR TITLE
Fix universal platform

### DIFF
--- a/apps/api/src/modules/device/discovery/discovery.service.ts
+++ b/apps/api/src/modules/device/discovery/discovery.service.ts
@@ -60,7 +60,7 @@ export class DiscoveryService {
     );
 
     // 2. Get device type offerings (skip if universal platform token is present — all device types are covered by getAllDeviceTypesOffering)
-    const hasUniversalPlatform = offeringDto.platforms?.includes(UNIVERSAL_PLATFORM_TOKEN);
+    const hasUniversalPlatform = offeringDto.platforms?.some(p => p.toLowerCase() === UNIVERSAL_PLATFORM_TOKEN);
     if (hasUniversalPlatform) {
       this.logger.debug(`Skipping per-device-type offering fetch — 'universal' platform token detected, all device types will be covered by getAllDeviceTypesOffering`);
     } else if (offeringDto.deviceType && offeringDto.deviceType.length > 0) {

--- a/apps/api/src/modules/device/discovery/discovery.service.ts
+++ b/apps/api/src/modules/device/discovery/discovery.service.ts
@@ -59,8 +59,12 @@ export class DiscoveryService {
         })
     );
 
-    // 2. Get device type offerings
-    if (offeringDto.deviceType && offeringDto.deviceType.length > 0) {
+    // 2. Get device type offerings (skip if universal platform token is present — all device types are covered by getAllDeviceTypesOffering)
+    const hasUniversalPlatform = offeringDto.platforms?.includes(UNIVERSAL_PLATFORM_TOKEN);
+    if (hasUniversalPlatform) {
+      this.logger.debug(`Skipping per-device-type offering fetch — 'universal' platform token detected, all device types will be covered by getAllDeviceTypesOffering`);
+    } else if (offeringDto.deviceType && offeringDto.deviceType.length > 0) {
+      this.logger.debug(`Fetching offerings for ${offeringDto.deviceType.length} device type(s): '${offeringDto.deviceType.join(', ')}'`);
       offeringDto.deviceType.forEach(deviceType => {
         promises.push(
           lastValueFrom(this.offeringService.getOfferingForDeviceType(
@@ -76,8 +80,9 @@ export class DiscoveryService {
 
     // 3. Get platform offerings (includes all device types under platform)
     if (offeringDto.platforms && offeringDto.platforms.length > 0) {
-      if (offeringDto.platforms.includes(UNIVERSAL_PLATFORM_TOKEN)) {
-        // Universal token: fetch offerings for ALL platforms at once
+      if (hasUniversalPlatform) {
+        // Universal token: fetch offerings for ALL platforms and ALL device types at once
+        this.logger.debug(`'Universal' platform token detected — fetching all platforms and all device types offerings`);
         promises.push(
           lastValueFrom(this.offeringService.getAllPlatformsOffering({ withDependencies: true }))
             .catch(err => {
@@ -85,7 +90,15 @@ export class DiscoveryService {
               return null;
             })
         );
+        promises.push(
+          lastValueFrom(this.offeringService.getAllDeviceTypesOffering({ withDependencies: true }))
+            .catch(err => {
+              this.logger.error(`Error getting all device types offering: ${err}`);
+              return null;
+            })
+        );
       } else {
+        this.logger.debug(`Fetching offerings for ${offeringDto.platforms.length} platform(s): ${offeringDto.platforms.join(', ')}`);
         offeringDto.platforms.forEach(platform => {
           promises.push(
             lastValueFrom(this.offeringService.getOfferingForPlatform({ platformIdentifier: platform }, { withDependencies: true }))

--- a/apps/api/src/modules/offering/offering.service.ts
+++ b/apps/api/src/modules/offering/offering.service.ts
@@ -22,6 +22,10 @@ export class OfferingService implements OnModuleInit {
     return this.offeringClient.send(OfferingTopics.GET_OFFERING_FOR_ALL_PLATFORMS, query ?? {});
   }
 
+  getAllDeviceTypesOffering(query?: { withDependencies?: boolean }) {
+    return this.offeringClient.send(OfferingTopics.GET_OFFERING_FOR_ALL_DEVICE_TYPES, query ?? {});
+  }
+
   getOfferingForDeviceType(params: DeviceTypeOfferingParams, query: DeviceTypeOfferingFilterQuery) {
     query.deviceTypeIdentifier = params.deviceTypeIdentifier;
     query.withDependencies = query.withDependencies ?? false;

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -83,6 +83,7 @@ export const OfferingTopics = {
     GET_OFFERING_FOR_PROJECT: `getapp-offering.get-offering-for-project${region}`,
     GET_OFFERING_FOR_ALL_PROJECTS: `getapp-offering.get-offering-for-all-project${region}`,
     GET_OFFERING_FOR_ALL_PLATFORMS: `getapp-offering.get-offering-for-all-platforms${region}`,
+    GET_OFFERING_FOR_ALL_DEVICE_TYPES: `getapp-offering.get-offering-for-all-device-types${region}`,
     GET_OFFER_OF_COMP: `getapp-offering.get-offering-of-comp${region}`,
 
     // Policies


### PR DESCRIPTION
This pull request updates the device discovery and offering services to better handle the "universal" platform token, ensuring that when it is present, offerings for all platforms and all device types are fetched efficiently. It also introduces a new method for fetching all device type offerings and adds the corresponding topic for microservice communication.

**Enhancements to universal platform handling:**

* In `discovery.service.ts`, the logic now checks for the presence of the universal platform token and, if detected, skips per-device-type offering fetches and instead fetches all device type offerings at once. Additional debug logging has been added to clarify when this path is taken.
* When the universal platform token is present in the platforms list, both all-platform and all-device-type offerings are fetched, with improved debug logging for clarity.

**Offering service and microservice topics:**

* `offering.service.ts` now includes a new `getAllDeviceTypesOffering` method to fetch offerings for all device types.
* A new topic, `GET_OFFERING_FOR_ALL_DEVICE_TYPES`, has been added to the `OfferingTopics` enum for microservice communication.