### PR TITLE
Add error handling for device context and microservice communication

### DIFF
--- a/apps/api/src/modules/device/discovery/discovery.service.ts
+++ b/apps/api/src/modules/device/discovery/discovery.service.ts
@@ -31,7 +31,9 @@ export class DiscoveryService {
 
 
   async deviceComponentDiscovery(dto: DiscoveryMessageV2Dto): Promise<DeviceComponentsOfferingDto> {
-    this.sendDeviceContextV2(dto);
+    this.sendDeviceContextV2(dto).catch(err => {
+      this.logger.error(`Error sending device context for device ${dto.id}: ${err}`);
+    });
 
     const offeringDto = ComponentOfferingRequestDto.fromDiscoveryMessageDto(dto);
     offeringDto.components = dto.softwareData?.components

--- a/libs/common/src/microservice-client/microservice-client.service.ts
+++ b/libs/common/src/microservice-client/microservice-client.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ClientKafka, ClientProxy, ClientProxyFactory } from '@nestjs/microservices';
-import { Observable, map, timeout } from 'rxjs';
+import { Observable, catchError, map, throwError, timeout } from 'rxjs';
 import { MicroserviceModuleOptions } from "./microservice-client.interface";
 import { KafkaHealthService, MSType, getClientConfig } from "./clients";
 import { ConfigService } from "@nestjs/config";
@@ -40,7 +40,11 @@ export class MicroserviceClient {
       pattern,
       this.formatData(data)
     ).pipe(
-      timeout(waitTime)
+      timeout(waitTime),
+      catchError(err => {
+        this.logger.error(`Microservice error for ${JSON.stringify(pattern)}: ${err?.message}`);
+        return throwError(() => err);
+      })
     );
   }
 


### PR DESCRIPTION
This pull request improves error handling and logging in both the device discovery service and the microservice client. The main focus is to ensure that errors are properly caught, logged, and propagated, which will help with debugging and reliability.

**Error handling and logging improvements:**

* In `discovery.service.ts`, errors from `sendDeviceContextV2` are now caught and logged, preventing unhandled promise rejections and making issues easier to trace.
* In `microservice-client.service.ts`, the RxJS pipeline in the `send` method now catches errors, logs them with details about the microservice pattern, and rethrows them for further handling.
* Added `catchError` and `throwError` imports from RxJS to support the new error handling logic in the microservice client.