### PR TITLE
feat: Proxy map requests to GetMap server

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -90,10 +90,11 @@ export class ApiModule implements NestModule {
     // Only on origin servers (not edge proxies — they forward everything via IS_PROXY).
     // Uses the GetMapController class to ensure only its routes are proxied,
     // not other controllers that happen to have "map" deeper in their paths.
+    // Also proxies device/discover/map — the map offering discovery endpoint.
     // TODO: Remove once GetMap is fully integrated into GetApp server.
     if (process.env.GETMAP_SERVER_URL && process.env.IS_PROXY !== "true") {
       consumer.apply(GetMapProxyMiddleware)
-        .forRoutes(GetMapController);
+        .forRoutes(GetMapController, { path: '*/device/discover/map', method: RequestMethod.POST });
     }
 
     if (process.env.IS_PROXY === "true") {

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -23,6 +23,8 @@ import { ApmModule } from 'nestjs-elastic-apm';
 import { LogRequestBodyMiddleware } from './utils/middleware/log-request-body.middleware';
 import { JsonBodyMiddleware } from './utils/middleware/json-body.middleware';
 import { ProxyMiddleware } from './utils/middleware/proxy.middleware';
+import { GetMapProxyMiddleware } from './utils/middleware/getmap-proxy.middleware';
+import { GetMapController } from './modules/get-map/get-map.controller';
 import { ApiEndpoints, DeliveryEndpoints } from '@app/common/utils/paths';
 import { HttpModule } from '@nestjs/axios';
 import { HttpClientService } from './utils/middleware/http-client.service';
@@ -81,6 +83,17 @@ export class ApiModule implements NestModule {
     consumer.apply(ClsMiddleware).forRoutes('*');
     if (process.env.ANALYTICS_SERVER_URL) {      
       consumer.apply(AnalyticsProxy).forRoutes(`*/analytics`);
+    }
+
+    // TEMPORARY: GetMap proxy — forward /map/* requests to GetMap server.
+    // Needed while GetMap runs as a separate deployment (develop-z branch).
+    // Only on origin servers (not edge proxies — they forward everything via IS_PROXY).
+    // Uses the GetMapController class to ensure only its routes are proxied,
+    // not other controllers that happen to have "map" deeper in their paths.
+    // TODO: Remove once GetMap is fully integrated into GetApp server.
+    if (process.env.GETMAP_SERVER_URL && process.env.IS_PROXY !== "true") {
+      consumer.apply(GetMapProxyMiddleware)
+        .forRoutes(GetMapController);
     }
 
     if (process.env.IS_PROXY === "true") {

--- a/apps/api/src/utils/middleware/getmap-proxy.middleware.ts
+++ b/apps/api/src/utils/middleware/getmap-proxy.middleware.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger, NestMiddleware } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { RequestHandler, createProxyMiddleware } from "http-proxy-middleware";
+import { ClientRequest } from "http";
+import { IncomingMessage } from "http";
+import { Request, Response } from "express";
+import { ClsService } from "nestjs-cls";
+import * as fs from "fs";
+
+/**
+ * TEMPORARY SOLUTION — Serving GetMap through GetApp.
+ *
+ * Proxies all `/map/*` HTTP requests to the GetMap server's API Gateway.
+ * This is needed because GetMap and GetApp are currently separate deployments
+ * (develop-z and develop branches), and we want all agent traffic to go
+ * through the GetApp server only.
+ *
+ * Activated only when `GETMAP_SERVER_URL` env var is set AND `IS_PROXY` is not "true".
+ * On proxy (edge) servers, all requests already go to the origin via ProxyMiddleware,
+ * and the origin handles the GetMap proxy.
+ *
+ * Supports two modes:
+ * - Plain HTTP (default): GETMAP_SERVER_URL=http://getmap:3000
+ * - mTLS (mutual TLS): GETMAP_MTLS=true + certificate env vars.
+ *   mTLS = both sides verify each other's certificate. Required when the
+ *   GetMap server is on a different network/cluster and demands client cert auth.
+ *   When both servers are in the same cluster, mTLS is NOT needed.
+ *
+ * TODO: Remove this middleware once GetMap is fully integrated into the GetApp server.
+ */
+@Injectable()
+export class GetMapProxyMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(GetMapProxyMiddleware.name);
+  private readonly proxy: RequestHandler;
+
+  constructor(configService: ConfigService, private cls: ClsService) {
+    const getMapServerUrl = configService.get<string>("GETMAP_SERVER_URL");
+    const useMtls = configService.get<string>("GETMAP_MTLS") === "true";
+
+    if (useMtls) {
+      // mTLS mode: GetMap server requires mutual certificate authentication.
+      // Same pattern as the existing ProxyMiddleware secure mode.
+      const key = fs.readFileSync(configService.get("GETMAP_CLIENT_KEY_PATH") || configService.get("CLIENT_KEY_PATH") || "").toString();
+      const cert = fs.readFileSync(configService.get("GETMAP_CLIENT_CERT_PATH") || configService.get("CLIENT_CERT_PATH") || "").toString();
+      const ca = fs.readFileSync(configService.get("GETMAP_CA_CERT_PATH") || configService.get("CA_CERT_PATH") || "").toString();
+
+      this.logger.log(`GetMap proxy configured in mTLS mode, target: ${getMapServerUrl}`);
+      this.proxy = createProxyMiddleware({
+        target: getMapServerUrl,
+        changeOrigin: true,
+        secure: true,
+        ssl: { key, cert, ca },
+        onProxyReq: this.onProxyReq.bind(this),
+        onProxyRes: this.onProxyRes.bind(this),
+        onError: this.onError.bind(this),
+      });
+    } else {
+      // Plain HTTP mode: same cluster, no certificate needed.
+      this.logger.log(`GetMap proxy configured in plain HTTP mode, target: ${getMapServerUrl}`);
+      this.proxy = createProxyMiddleware({
+        target: getMapServerUrl,
+        changeOrigin: true,
+        onProxyReq: this.onProxyReq.bind(this),
+        onProxyRes: this.onProxyRes.bind(this),
+        onError: this.onError.bind(this),
+      });
+    }
+  }
+
+  use(req: any, res: any, next: (error?: Error | any) => void) {
+    this.proxy(req, res, next);
+  }
+
+  private onProxyReq(proxyReq: ClientRequest, req: Request, _res: Response) {
+    const traceId = this.cls.getId();
+    if (traceId) {
+      proxyReq.setHeader("x-request-id", traceId);
+    }
+    this.logger.debug(`GetMap proxy → ${req.method} ${req.originalUrl}`);
+  }
+
+  private onProxyRes(proxyRes: IncomingMessage, req: Request, _res: Response) {
+    this.logger.debug(`GetMap proxy ← ${req.originalUrl} [${proxyRes.statusCode}]`);
+  }
+
+  private onError(error: any, req: Request, res: Response) {
+    this.logger.error(`GetMap proxy error for ${req.originalUrl}: ${error.message}`);
+    if (!res.headersSent) {
+      res.status(502).json({
+        error: "GetMap server unavailable",
+        message: error.message,
+      });
+    }
+  }
+}


### PR DESCRIPTION
**Description:**

Adds a transparent HTTP proxy layer that forwards all map-related requests to the GetMap server (deployed separately on branch `develop-z`). This is a temporary solution while the servers are separate — will be removed once GetMap is fully integrated.

**What was done:**
- New middleware `GetMapProxyMiddleware` — forwards requests to `GETMAP_SERVER_URL` using `http-proxy-middleware`
- Supports plain HTTP (same-cluster) and mTLS (cross-cluster) via `GETMAP_MTLS=true`
- Proxied routes: all `GetMapController` routes (`/map/*`) + `POST /device/discover/map` (map offering discovery)
- Only active when `GETMAP_SERVER_URL` is set AND `IS_PROXY !== "true"` (origin servers only)
- Adds `x-request-id` header for distributed tracing
- Returns 502 with descriptive error if GetMap server is unreachable

**Configuration:**
```env
GETMAP_SERVER_URL=https://api-getmap.apps.getapp.sh
# Optional for mTLS:
GETMAP_MTLS=true
GETMAP_CLIENT_KEY_PATH=/path/to/key
GETMAP_CLIENT_CERT_PATH=/path/to/cert
GETMAP_CA_CERT_PATH=/path/to/ca
```

**Files changed:**
- `api/apps/api/src/utils/middleware/getmap-proxy.middleware.ts` — **new file**
- `api/apps/api/src/api.module.ts` — middleware registration
